### PR TITLE
Improvements

### DIFF
--- a/components/db_buffer/db_buffer.go
+++ b/components/db_buffer/db_buffer.go
@@ -164,6 +164,11 @@ func (b *Buffer) callSync() {
 	}
 
 	b.onDBSyncComplete(&syncResult)
+
+	select {
+	case b.SyncComplete <- syncResult:
+	default:
+	}
 }
 
 func (b *Buffer) checkIsTimeToSync() {

--- a/components/db_buffer/db_buffer.go
+++ b/components/db_buffer/db_buffer.go
@@ -68,6 +68,9 @@ func (b *Buffer) Start() {
 
 // Stop stops listening for syncing triggering events
 func (b *Buffer) Stop() {
+	b.syncMutex.Lock()
+	defer b.syncMutex.Unlock()
+
 	close(b.newDataChan)
 	b.syncTicker.Stop()
 	b.exitChan <- true

--- a/components/workQueue/worker_queued.go
+++ b/components/workQueue/worker_queued.go
@@ -1,5 +1,7 @@
 package WorkQueue
 
+import "go.uber.org/zap"
+
 type IQueuedWorker interface {
 	Start()
 	DoWork(Work)
@@ -23,6 +25,10 @@ type WorkQueue struct {
 	End         chan bool
 }
 
+func (w WorkQueue) Stop() {
+	w.End <- true
+}
+
 func (w WorkQueue) ListenForJobs(cb func(Work)) {
 	go func() {
 		for {
@@ -31,6 +37,7 @@ func (w WorkQueue) ListenForJobs(cb func(Work)) {
 			case job := <-w.JobsChan:
 				cb(job)
 			case <-w.End:
+				zap.S().Info("[WorkQueue]- Stopped listening for jobs")
 				return
 			}
 		}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/ThreeDotsLabs/watermill v1.1.1
 	github.com/coinbase/rosetta-sdk-go v0.6.10
 	github.com/eapache/queue v1.1.0
+	github.com/go-chi/chi v4.0.2+incompatible
 	github.com/gorilla/mux v1.8.0
 	github.com/hasura/go-graphql-client v0.7.0
 	github.com/jszwec/csvutil v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -166,6 +166,7 @@ github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.6.3 h1:ahKqKTFpO5KTPHxWZjEdPScmYaGtLo8Y4DMHoEsnp14=
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
+github.com/go-chi/chi v4.0.2+incompatible h1:maB6vn6FqCxrpz4FqWdh4+lwpyZIQS7YEAUcHlgXVRs=
 github.com/go-chi/chi v4.0.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/indexer/status_server.go
+++ b/indexer/status_server.go
@@ -1,0 +1,46 @@
+package indexer
+
+import (
+	"context"
+	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/middleware"
+	"go.uber.org/zap"
+	"net/http"
+)
+
+type StatusServer struct {
+	server *http.Server
+}
+
+func NewStatusServer(i *Indexer) *StatusServer {
+	r := chi.NewRouter()
+	s := &http.Server{Addr: ":3300", Handler: r}
+
+	// setup endpoints
+	r.Use(middleware.Heartbeat("/health"))
+	r.Get("/stop", func(w http.ResponseWriter, r *http.Request) {
+		i.StopIndexing()
+		_, err := w.Write([]byte("OK"))
+		if err != nil {
+			return
+		}
+	})
+
+	return &StatusServer{server: s}
+}
+
+func (s *StatusServer) Start() {
+	go func() {
+		err := s.server.ListenAndServe()
+		if err != nil {
+			zap.S().Infof("erron on StatusServer: %s", err.Error())
+		}
+	}()
+}
+
+func (s *StatusServer) Stop() {
+	err := s.server.Shutdown(context.Background())
+	if err != nil {
+		zap.S().Errorf("StatusServer: %s", err.Error())
+	}
+}

--- a/indexer/tests/integration_test.go
+++ b/indexer/tests/integration_test.go
@@ -96,18 +96,18 @@ func TestBasicIndexerWithExit(t *testing.T) {
 	zidx.BaseIndexer.SetGetMissingHeightsFn(zidx.MockGetMissingHeights)
 
 	go func() {
-		for {
-			time.Sleep(30 * time.Second)
-			heights, err := tracker.GetTrackedHeights(testId, dbConn)
-			if err != nil {
-				return
-			}
-
-			if len(*heights) > 200 {
-				t.Error("indexer did not stop properly!")
-			}
-		}
+		time.Sleep(60 * time.Second)
+		t.Error("Test timeout")
 	}()
 
 	zidx.BaseIndexer.StartIndexing()
+
+	heights, err := tracker.GetTrackedHeights(testId, dbConn)
+	if err != nil {
+		return
+	}
+
+	if len(*heights) != 20 {
+		t.Error("indexer did not stop properly!")
+	}
 }

--- a/indexer/tests/integration_test.go
+++ b/indexer/tests/integration_test.go
@@ -36,7 +36,7 @@ func setupTestingDB(db *gorm.DB) {
 	}
 }
 
-func Test_BasicIndexer(t *testing.T) {
+func TestBasicIndexer(t *testing.T) {
 	dbConn := utils.InitdbConn()
 	setupTestingDB(dbConn)
 	err := dbConn.AutoMigrate(DummyBlock{})
@@ -74,7 +74,7 @@ func Test_BasicIndexer(t *testing.T) {
 	}
 }
 
-func Test_BasicIndexerWithExit(t *testing.T) {
+func TestBasicIndexerWithExit(t *testing.T) {
 	dbConn := utils.InitdbConn()
 	setupTestingDB(dbConn)
 	err := dbConn.AutoMigrate(DummyBlock{})

--- a/indexer/tests/mock_worker.go
+++ b/indexer/tests/mock_worker.go
@@ -101,39 +101,13 @@ func (i *MockIndexer) MockSyncToDB() db_buffer.SyncResult {
 }
 
 func (i *MockIndexer) MockSyncToDBWithExit() db_buffer.SyncResult {
-	fmt.Println("Syncing to DB")
-
-	data, err := i.BaseIndexer.DBBuffer.GetData("dummy")
-	if err != nil {
-		panic(err)
-	}
-
-	if len(data) == 0 {
-		return db_buffer.SyncResult{}
-	}
-
-	var dummyBlocks []DummyBlock
-	var heights []uint64
-	for i, b := range data {
-		block := b.(DummyBlock)
-		height, _ := strconv.Atoi(i)
-		dummyBlocks = append(dummyBlocks, block)
-		heights = append(heights, uint64(height))
-	}
+	res := i.MockSyncToDB()
 
 	// trigger onExit call
 	i.BaseIndexer.StopIndexing()
 	time.Sleep(10 * time.Second)
-
-	// Will panic if tries to insert a duplicate
-	tx := i.BaseIndexer.DbConn.Create(dummyBlocks)
-	if tx.Error != nil {
-		panic(tx.Error)
-	}
-
-	return db_buffer.SyncResult{
-		SyncedHeights: &heights,
-	}
+	
+	return res
 }
 
 func (i *MockIndexer) NewMockWorker(id string, workerChannel chan chan WorkQueue.Work) WorkQueue.QueuedWorker {

--- a/indexer/tests/mock_worker.go
+++ b/indexer/tests/mock_worker.go
@@ -100,6 +100,42 @@ func (i *MockIndexer) MockSyncToDB() db_buffer.SyncResult {
 	}
 }
 
+func (i *MockIndexer) MockSyncToDBWithExit() db_buffer.SyncResult {
+	fmt.Println("Syncing to DB")
+
+	data, err := i.BaseIndexer.DBBuffer.GetData("dummy")
+	if err != nil {
+		panic(err)
+	}
+
+	if len(data) == 0 {
+		return db_buffer.SyncResult{}
+	}
+
+	var dummyBlocks []DummyBlock
+	var heights []uint64
+	for i, b := range data {
+		block := b.(DummyBlock)
+		height, _ := strconv.Atoi(i)
+		dummyBlocks = append(dummyBlocks, block)
+		heights = append(heights, uint64(height))
+	}
+
+	// trigger onExit call
+	i.BaseIndexer.StopIndexing()
+	time.Sleep(10 * time.Second)
+
+	// Will panic if tries to insert a duplicate
+	tx := i.BaseIndexer.DbConn.Create(dummyBlocks)
+	if tx.Error != nil {
+		panic(tx.Error)
+	}
+
+	return db_buffer.SyncResult{
+		SyncedHeights: &heights,
+	}
+}
+
 func (i *MockIndexer) NewMockWorker(id string, workerChannel chan chan WorkQueue.Work) WorkQueue.QueuedWorker {
 	worker := MockWorker{
 		buffer: i.BaseIndexer.DBBuffer,

--- a/indexer/tests/mock_worker.go
+++ b/indexer/tests/mock_worker.go
@@ -14,6 +14,12 @@ import (
 	"time"
 )
 
+const (
+	MockSyncBlockPeriod = 10
+	MockSyncTimePeriod  = 5 * time.Second
+	MockId              = "test"
+)
+
 type DummyBlock struct {
 	Height uint64 `gorm:"unique"`
 	Hash   string
@@ -39,11 +45,11 @@ func NewMockIndexer(dbConn *gorm.DB, id string, tip, genesis uint64) *MockIndexe
 		EnableBuffer: true,
 		ComponentsCfg: indexer.ComponentsCfg{
 			DBBufferCfg: db_buffer.Config{
-				SyncTimePeriod:     5 * time.Second,
-				SyncBlockThreshold: 10,
+				SyncTimePeriod:     MockSyncTimePeriod,
+				SyncBlockThreshold: MockSyncBlockPeriod,
 			},
 			DispatcherCfg: WorkQueue.DispatcherConfig{
-				RetryTimeout: 10 * time.Second,
+				RetryTimeout: MockSyncTimePeriod,
 			},
 		},
 	}
@@ -96,6 +102,7 @@ func (i *MockIndexer) MockSyncToDB() db_buffer.SyncResult {
 	}
 
 	return db_buffer.SyncResult{
+		Id:            MockId,
 		SyncedHeights: &heights,
 	}
 }

--- a/indexer/tests/mock_worker.go
+++ b/indexer/tests/mock_worker.go
@@ -106,7 +106,7 @@ func (i *MockIndexer) MockSyncToDBWithExit() db_buffer.SyncResult {
 	// trigger onExit call
 	i.BaseIndexer.StopIndexing()
 	time.Sleep(10 * time.Second)
-	
+
 	return res
 }
 


### PR DESCRIPTION
- Implement graceful shutdown
- Add `StatusServer` for better k8s rollout updates: `/health `(heartbit) and `/stop` endpoints are enabled to be used in `PreStop` and `livenessProve` configs
- Closes #26 


<!-- ClickUpRef: 2hxxju6 -->
:link: [zboto Link](https://app.clickup.com/t/2hxxju6)